### PR TITLE
fix(run.py): Using "safe_load" to load the test list

### DIFF
--- a/run.py
+++ b/run.py
@@ -74,7 +74,7 @@ class Run:
     def _testsList(self):
         ignore_tests = []
         with open(self._testsFile()) as f:
-            content = yaml.load(f)
+            content = yaml.safe_load(f)
             if 'tests' in content:
                 ignore_tests.extend(content['tests'])
         return ignore_tests


### PR DESCRIPTION
```
01:18:15    File "main.py", line 78, in <module>
01:18:15      cql_cassandra_version=arguments.cql_cassandra_version)
01:18:15    File "main.py", line 23, in main
01:18:15      results[version] = test_run.run()
01:18:15    File "/jenkins/workspace/scylla-master/driver-tests/cpp-driver-matrix-test/cpp-driver-matrix/run.py", line 151, in run
01:18:15      gtest_filter = f"-{':'.join(self._testsList())}" if self._testsList() else '*'
01:18:15    File "/jenkins/workspace/scylla-master/driver-tests/cpp-driver-matrix-test/cpp-driver-matrix/run.py", line 77, in _testsList
01:18:15      content = yaml.load(f)
01:18:15  TypeError: load() missing 1 required positional argument: 'Loader'
```