### PR TITLE
Skip a few test the proven to be flaky on datastax versions

### DIFF
--- a/versions/datastax/2.0/ignore.yaml
+++ b/versions/datastax/2.0/ignore.yaml
@@ -6,6 +6,7 @@ tests:
   - ConsistencyTwoNodeClusterTests.Integration_Cassandra_SimpleEachQuorum
   - ControlConnectionTests.Integration_Cassandra_TopologyChange
   - ControlConnectionTwoNodeClusterTests.Integration_Cassandra_Reconnection
+  - ControlConnectionTwoNodeClusterTests.Integration_Cassandra_StatusChange
   - CustomPayloadTests*
   - DbaasTests*
   - DcAwarePolicyTest.Integration_Cassandra_UsedHostsRemoteDc
@@ -15,6 +16,7 @@ tests:
   - HeartbeatTests.Integration_Cassandra_HeartbeatFailed
   - MetricsTests.Integration_Cassandra_SpeculativeExecutionRequests
   - MetricsTests.Integration_Cassandra_StatsConnections
+  - MetricsTests.Integration_Cassandra_ErrorsConnectionTimeouts
   - PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare
   - ServerSideFailureTests.Integration_Cassandra_Warning
   - ServerSideFailureTests.Integration_Cassandra_ErrorFunctionFailure

--- a/versions/datastax/2.15.0/ignore.yaml
+++ b/versions/datastax/2.15.0/ignore.yaml
@@ -6,6 +6,7 @@ tests:
   - ConsistencyTwoNodeClusterTests.Integration_Cassandra_SimpleEachQuorum
   - ControlConnectionTests.Integration_Cassandra_TopologyChange
   - ControlConnectionTwoNodeClusterTests.Integration_Cassandra_Reconnection
+  - ControlConnectionTwoNodeClusterTests.Integration_Cassandra_StatusChange
   - CustomPayloadTests*
   - DbaasTests*
   - DcAwarePolicyTest.Integration_Cassandra_UsedHostsRemoteDc
@@ -15,6 +16,7 @@ tests:
   - HeartbeatTests.Integration_Cassandra_HeartbeatFailed
   - MetricsTests.Integration_Cassandra_SpeculativeExecutionRequests
   - MetricsTests.Integration_Cassandra_StatsConnections
+  - MetricsTests.Integration_Cassandra_ErrorsConnectionTimeouts
   - PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare
   - ServerSideFailureTests.Integration_Cassandra_Warning
   - ServerSideFailureTests.Integration_Cassandra_ErrorFunctionFailure

--- a/versions/datastax/2.15.3/ignore.yaml
+++ b/versions/datastax/2.15.3/ignore.yaml
@@ -6,6 +6,7 @@ tests:
   - ConsistencyTwoNodeClusterTests.Integration_Cassandra_SimpleEachQuorum
   - ControlConnectionTests.Integration_Cassandra_TopologyChange
   - ControlConnectionTwoNodeClusterTests.Integration_Cassandra_Reconnection
+  - ControlConnectionTwoNodeClusterTests.Integration_Cassandra_StatusChange
   - CustomPayloadTests*
   - DbaasTests*
   - DcAwarePolicyTest.Integration_Cassandra_UsedHostsRemoteDc
@@ -15,6 +16,7 @@ tests:
   - HeartbeatTests.Integration_Cassandra_HeartbeatFailed
   - MetricsTests.Integration_Cassandra_SpeculativeExecutionRequests
   - MetricsTests.Integration_Cassandra_StatsConnections
+  - MetricsTests.Integration_Cassandra_ErrorsConnectionTimeouts
   - PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare
   - ServerSideFailureTests.Integration_Cassandra_Warning
   - ServerSideFailureTests.Integration_Cassandra_ErrorFunctionFailure

--- a/versions/datastax/2.16.0/ignore.yaml
+++ b/versions/datastax/2.16.0/ignore.yaml
@@ -6,6 +6,7 @@ tests:
   - ConsistencyTwoNodeClusterTests.Integration_Cassandra_SimpleEachQuorum
   - ControlConnectionTests.Integration_Cassandra_TopologyChange
   - ControlConnectionTwoNodeClusterTests.Integration_Cassandra_Reconnection
+  - ControlConnectionTwoNodeClusterTests.Integration_Cassandra_StatusChange
   - CustomPayloadTests*
   - DbaasTests*
   - DcAwarePolicyTest.Integration_Cassandra_UsedHostsRemoteDc
@@ -15,6 +16,7 @@ tests:
   - HeartbeatTests.Integration_Cassandra_HeartbeatFailed
   - MetricsTests.Integration_Cassandra_SpeculativeExecutionRequests
   - MetricsTests.Integration_Cassandra_StatsConnections
+  - MetricsTests.Integration_Cassandra_ErrorsConnectionTimeouts
   - PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare
   - ServerSideFailureTests.Integration_Cassandra_Warning
   - ServerSideFailureTests.Integration_Cassandra_ErrorFunctionFailure


### PR DESCRIPTION
* MetricsTests.Integration_Cassandra_ErrorsConnectionTimeouts
```
/jenkins/workspace/scylla-master/driver-tests/cpp-driver-matrix-test/cpp-driver-datastax/tests/src/integration/tests/test_control_connection.cpp:375
Value of: wait_for_logger(logger_nodes.size())
  Actual: false
Expected: true
```

* ControlConnectionTwoNodeClusterTests.Integration_Cassandra_StatusChange

```
/jenkins/workspace/scylla-master/driver-tests/cpp-driver-matrix-test/cpp-driver-datastax/tests/src/integration/tests/test_metrics.cpp:76
Expected: (2u) >= (metrics.errors.connection_timeouts), actual: 2 vs 5
```