### PR TITLE
Skip one flaky test also for the Scylla backend

### DIFF
--- a/versions/scylla/2.0/ignore.yaml
+++ b/versions/scylla/2.0/ignore.yaml
@@ -15,6 +15,7 @@ tests:
   - HeartbeatTests.Integration_Cassandra_HeartbeatFailed
   - MetricsTests.Integration_Cassandra_SpeculativeExecutionRequests
   - MetricsTests.Integration_Cassandra_StatsConnections
+  - MetricsTests.Integration_Cassandra_ErrorsConnectionTimeouts
   - PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare
   - ServerSideFailureTests.Integration_Cassandra_Warning
   - ServerSideFailureTests.Integration_Cassandra_ErrorFunctionFailure

--- a/versions/scylla/2.15.2-1/ignore.yaml
+++ b/versions/scylla/2.15.2-1/ignore.yaml
@@ -15,6 +15,7 @@ tests:
   - HeartbeatTests.Integration_Cassandra_HeartbeatFailed
   - MetricsTests.Integration_Cassandra_SpeculativeExecutionRequests
   - MetricsTests.Integration_Cassandra_StatsConnections
+  - MetricsTests.Integration_Cassandra_ErrorsConnectionTimeouts
   - PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare
   - ServerSideFailureTests.Integration_Cassandra_Warning
   - ServerSideFailureTests.Integration_Cassandra_ErrorFunctionFailure

--- a/versions/scylla/2.16.2-1/ignore.yaml
+++ b/versions/scylla/2.16.2-1/ignore.yaml
@@ -15,6 +15,7 @@ tests:
   - HeartbeatTests.Integration_Cassandra_HeartbeatFailed
   - MetricsTests.Integration_Cassandra_SpeculativeExecutionRequests
   - MetricsTests.Integration_Cassandra_StatsConnections
+  - MetricsTests.Integration_Cassandra_ErrorsConnectionTimeouts
   - PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare
   - ServerSideFailureTests.Integration_Cassandra_Warning
   - ServerSideFailureTests.Integration_Cassandra_ErrorFunctionFailure


### PR DESCRIPTION
The `MetricsTests.Integration_Cassandra_ErrorsConnectionTimeouts` test became also flaky
on the `Scylla` backend which has been skipped for pretty long time on the `Cassandra` one exactly for the `flakiness`.

So, skip it also for the `Scylla` backend, because it started being flaky here too.