### PR TITLE
Fix scylla tag fetching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+.vscode

--- a/main.py
+++ b/main.py
@@ -75,7 +75,7 @@ def extract_n_latest_repo_tags(repo_directory: str, major_versions: List[str], l
     commands = [f"cd {repo_directory}", "git checkout .", ]
     if not os.environ.get("DEV_MODE", False):
         commands.append("git fetch -p --all")
-    commands.append(f"git tag --sort=-creatordate {filter_version} | grep '^[0-9]*\.[0-9]*\.[0-9]*$'")
+    commands.append(f"git tag --sort=-creatordate {filter_version} | grep -E '^[0-9]*\.[0-9]*\.[0-9]*(-1)?$'")
 
     selected_tags = {}
     ignore_tags = set()


### PR DESCRIPTION
Scylla cpp-driver version tags can end with `-1` suffix (for some, unknown
to me reason). This patch fixes the tag fetching logic to handle this case.

Currently, the matrix job fails because we fail to fetch scylla driver tags.